### PR TITLE
fix change restore status

### DIFF
--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -683,6 +683,10 @@ if [[ "${CHECKDB_MODE}" != "No" ]]; then
     else
     sed -i 's/Amcheck_validation=0/Amcheck_validation=1/g' "${status_file}"
     fi
+else
+    sed -i 's/PG_checksums_validation=0/PG_checksums_validation=1/g' "${status_file}"
+    sed -i 's/Data_validation=0/Data_validation=1/g' "${status_file}"
+    sed -i 's/Amcheck_validation=0/Amcheck_validation=1/g' "${status_file}"
 fi
 # [ optional ] clear data directory
 if [[ "${CLEAR}" = "yes" ]]; then


### PR DESCRIPTION
If CHECK_MODE=NO, then skipped "if" block where changed status for PG_checksum_validation/Data_validation/Am check_validation

I added "else" block. Now, if CHECKDB_MODE=NO, then status for PG_checksum_validation/Data_validation/Am check_validation automatic change from 0 to 1, and result status will be correct.