### PR TITLE
change result status for zabbix when script end with error

### DIFF
--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -45,6 +45,7 @@ function warnmsg(){
 function error(){
     msg="$1"
     echo -e "$(date "+%F %T") \e[91mERROR:\e[0m $msg"
+    sed -i 's/Result_status=1/Result_status=0/g' "${status_file}"
     logger -p user.error -t "$(basename "$0")" "$msg"
     # sendmail
     if [[ "${REPORT}" = "yes" ]]; then sendmail; fi


### PR DESCRIPTION
Fixed one case:
If postgres start after restore more time that defined in script "--timeout=600", script ended with error and result_status didn`t change