### PR TITLE
allocate a free port before starting Postgres (not earlier)

### DIFF
--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -467,7 +467,8 @@ function pg_start(){
         info "PostgreSQL is already running"
     else
         info "Starting PostgreSQL on port ${PGPORT}"
-        if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 1800 &> /dev/null
+        if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 1800 \
+            > /tmp/pgbackrest_auto_pg_start_${FROM}.log 2>&1
         then
             error "PostgreSQL instance ${PGPORT} start failed"
         else

--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -420,10 +420,10 @@ function pg_stop_check(){
     "${PG_BIN_DIR}"/pg_ctl status -D "${PGDATA}" &> /dev/null
     code=$?
     if [[ $code -eq 3 ]]; then
-        info "PostgreSQL instance ${PGPORT} not running"
+        info "PostgreSQL instance not running"
         status=ok
     elif [[ $code -eq 0 ]]; then
-        info "Wait PostgreSQL instance ${PGPORT} stop: wait ${sleep}s"
+        info "Wait PostgreSQL instance stop: wait ${sleep}s"
         sleep ${sleep}s
     elif [[ $code -eq 4 ]]; then
         status=ok
@@ -440,9 +440,9 @@ function pg_stop(){
         info "PostgreSQL stop"
         if "${PG_BIN_DIR}"/pg_ctl stop -D "${PGDATA}" -m fast -w -t 1800 &> /dev/null
         then
-            info "PostgreSQL instance ${PGPORT} stopped"
+            info "PostgreSQL instance stopped"
         else
-            warnmsg "PostgreSQL instance ${PGPORT} stop failed"
+            warnmsg "PostgreSQL instance stop failed"
         fi
     fi
 }

--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -8,7 +8,7 @@
 # for "--report": sendemail
 # Run as user: postgres
 
-ver="1.5.0"
+ver="1.5.1"
 
 # variables for function "sendmail()"
 smtp_server="10.128.64.5:25"
@@ -335,7 +335,7 @@ then
 fi
 
 # checkdb_mode
-if [[ -z $CHECKDB ]]; then 
+if [[ -z $CHECKDB ]]; then
     [[ "${DUMMYDUMP}" = "yes" ]] && CHECKDB_MODE+="dummy-dump "
     [[ "${CHECKSUMS}" = "yes" ]] && CHECKDB_MODE+="checksums "
     [[ "${AMCHECK}" = "yes" ]] && CHECKDB_MODE+="amcheck "
@@ -461,12 +461,18 @@ function pgisready(){
 
 function pg_start(){
     pg_port_pick
-    info "PostgreSQL start"
-    if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 1800 &> /dev/null
-    then
-        error "PostgreSQL instance ${PGPORT} start failed"
+    "${PG_BIN_DIR}"/pg_ctl status -D "${PGDATA}" &> /dev/null
+    code=$?
+    if [[ $code -eq 0 ]]; then
+        info "PostgreSQL is already running"
     else
-        pgisready 1> /dev/null
+        info "Starting PostgreSQL on port ${PGPORT}"
+        if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 1800 &> /dev/null
+        then
+            error "PostgreSQL instance ${PGPORT} start failed"
+        else
+            pgisready 1> /dev/null
+        fi
     fi
 }
 
@@ -650,7 +656,6 @@ STEP=1
 rm -f "${log}"
 touch "${log}"
 exec &> >(tee -a "${log}")
-pg_port_pick
 info "[STEP $((STEP++))]: Starting"
 # Reset values in status file before new restore
 printf "Restore_from_backup=0\nRestoring_from_archive=0\nData_validation=0\nPG_checksums_validation=0\nAmcheck_validation=0\nResult_status=1" > "${status_file}"
@@ -659,13 +664,12 @@ if [[ "$NORESTORE" = "yes" ]]; then
     info "Starting. Run settings: Log: ${log}"
     info "Starting. Run settings: Lock run: ${lock}"
     info "Starting. PostgreSQL version: ${PGVER}"
-    info "Starting. PostgreSQL port: ${PGPORT}"
+    info "Starting. PostgreSQL data directory: ${PGDATA}"
     info "Starting. PostgreSQL Database Validation: ${CHECKDB_MODE}"
     if [[ "${CLEAR}" = "yes" ]]; then info "Starting. Clear Data Directory after restore: ${CLEAR}";fi
     info "[STEP $((STEP++))]: PostgreSQL Starting"
-    if ! pgisready; then pg_start
+    pg_start
     cycle_simple pgisready
-    fi
     sed -i 's/Restore_from_backup=0/Restore_from_backup=1/g' "${status_file}"
     sed -i 's/Restoring_from_archive=0/Restore_from_archive=1/g' "${status_file}"
 else
@@ -674,7 +678,7 @@ else
     info "Starting. Run settings: Log: ${log}"
     info "Starting. Run settings: Lock run: ${lock}"
     info "Starting. PostgreSQL version: ${PGVER}"
-    info "Starting. PostgreSQL port: ${PGPORT}"
+    info "Starting. PostgreSQL data directory: ${PGDATA}"
     info "Starting. PostgreSQL Database Validation: ${CHECKDB_MODE}"
     if [[ "${CLEAR}" = "yes" ]]; then info "Starting. Clear Data Directory after restore: ${CLEAR}";fi
     check_mistake_run


### PR DESCRIPTION
Due to parallel activity (for example, test recovery of other Postgres instances), a situation could arise when one port was allocated before the recovery and before the starting of Postgres another port was already allocated since the previous one was already occupied by another PostgreSQL instance, which could be misleading.

Examples:

```
2023-05-18 04:00:09 INFO: [STEP 1]: Starting
2023-05-18 04:00:09 INFO: Starting. Restore Type: Full PostgreSQL Restore FROM Stanza: drmdb-cluster --> TO Directory: /data/restore/drmdb-cluster
2023-05-18 04:00:09 INFO: Starting. Restore Settings: immediate
2023-05-18 04:00:09 INFO: Starting. Run settings: Log: /var/log/pgbackrest/pgbackrest_auto_drmdb-cluster.log
2023-05-18 04:00:09 INFO: Starting. Run settings: Lock run: /tmp/pgbackrest_auto_drmdb-cluster.lock
2023-05-18 04:00:09 INFO: Starting. PostgreSQL version: 13
2023-05-18 04:00:09 INFO: Starting. PostgreSQL port: 5435
2023-05-18 04:00:09 INFO: Starting. PostgreSQL Database Validation: checksums
2023-05-18 04:00:09 INFO: Starting. Clear Data Directory after restore: yes
2023-05-18 04:00:09 WARN: Restoring to /data/restore/drmdb-cluster Waiting 30 seconds. The directory will be overwritten. If mistake, press ^C
2023-05-18 04:00:39 INFO: [STEP 2]: Stopping PostgreSQL
2023-05-18 04:00:40 INFO: PostgreSQL stop
2023-05-18 04:00:49 INFO: PostgreSQL instance 5435 stopped
2023-05-18 04:00:49 INFO: attempt: 1/3600
2023-05-18 04:00:49 INFO: PostgreSQL check status
2023-05-18 04:00:49 INFO: PostgreSQL instance 5435 not running
2023-05-18 04:00:49 INFO: [STEP 3]: Restoring from backup
2023-05-18 04:00:50 INFO: See detailed log in the file /var/log/pgbackrest/drmdb-cluster-restore.log
2023-05-18 04:00:50 INFO: Restore from backup started. Type: Full PostgreSQL Restore
pgbackrest --config=/etc/pgbackrest.conf --stanza=drmdb-cluster --pg1-path=/data/restore/drmdb-cluster  --type=immediate --delta restore --process-max=2 --log-level-console=error --log-level-file=detail --recovery-option=recovery_target_action=promote --tablespace-map-all=/data/restore/drmdb-cluster_remapped_tablespaces
2023-05-18 10:39:18 INFO: Restore from backup done
2023-05-18 10:39:18 INFO: [STEP 4]: PostgreSQL Starting for recovery
2023-05-18 10:39:18 INFO: PostgreSQL start
2023-05-18 11:09:24 ERROR: PostgreSQL instance 5432 start failed
```

```
2023-05-18 08:00:02 INFO: [STEP 1]: Starting
2023-05-18 08:00:02 INFO: Starting. Restore Type: Full PostgreSQL Restore FROM Stanza: mdsdb-cluster --> TO Directory: /data/restore/mdsdb-cluster
2023-05-18 08:00:02 INFO: Starting. Restore Settings: immediate
2023-05-18 08:00:02 INFO: Starting. Run settings: Log: /var/log/pgbackrest/pgbackrest_auto_mdsdb-cluster.log
2023-05-18 08:00:02 INFO: Starting. Run settings: Lock run: /tmp/pgbackrest_auto_mdsdb-cluster.lock
2023-05-18 08:00:02 INFO: Starting. PostgreSQL version: 14
2023-05-18 08:00:02 INFO: Starting. PostgreSQL port: 5432
2023-05-18 08:00:02 INFO: Starting. PostgreSQL Database Validation: checksums
2023-05-18 08:00:02 INFO: Starting. Clear Data Directory after restore: yes
2023-05-18 08:00:02 WARN: Restoring to /data/restore/mdsdb-cluster Waiting 30 seconds. The directory will be overwritten. If mistake, press ^C
2023-05-18 08:00:32 INFO: [STEP 2]: Stopping PostgreSQL
2023-05-18 08:00:32 INFO: PostgreSQL stop
2023-05-18 08:00:33 INFO: PostgreSQL instance 5432 stopped
2023-05-18 08:00:33 INFO: attempt: 1/3600
2023-05-18 08:00:33 INFO: PostgreSQL check status
2023-05-18 08:00:33 INFO: PostgreSQL instance 5432 not running
2023-05-18 08:00:33 INFO: [STEP 3]: Restoring from backup
2023-05-18 08:00:33 INFO: See detailed log in the file /var/log/pgbackrest/mdsdb-cluster-restore.log
2023-05-18 08:00:33 INFO: Restore from backup started. Type: Full PostgreSQL Restore
pgbackrest --config=/etc/pgbackrest.conf --stanza=mdsdb-cluster --pg1-path=/data/restore/mdsdb-cluster  --type=immediate --delta restore --process-max=2 --log-level-console=error --log-level-file=detail --recovery-option=recovery_target_action=promote --tablespace-map-all=/data/restore/mdsdb-cluster_remapped_tablespaces
2023-05-18 11:40:58 INFO: Restore from backup done
2023-05-18 11:40:58 INFO: [STEP 4]: PostgreSQL Starting for recovery
2023-05-18 11:40:59 INFO: PostgreSQL start
2023-05-18 12:11:09 ERROR: PostgreSQL instance 5433 start failed
```

Now a free port for PostgreSQL is allocated immediately before starting Postgres.

#### Additionally

Added a log file for debugging Postgres startup problems 6caf1e0682e99bd5b44ff72c52f9b87887e57a42