### PR TITLE
Increase the timeout for the pg_ctl start command

### DIFF
--- a/pgbackrest_auto
+++ b/pgbackrest_auto
@@ -467,7 +467,7 @@ function pg_start(){
         info "PostgreSQL is already running"
     else
         info "Starting PostgreSQL on port ${PGPORT}"
-        if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 1800 \
+        if ! "${PG_BIN_DIR}"/pg_ctl -o "-p ${PGPORT}" start -D "${PGDATA}" -w -t 36000 \
             > /tmp/pgbackrest_auto_pg_start_${FROM}.log 2>&1
         then
             error "PostgreSQL instance ${PGPORT} start failed"


### PR DESCRIPTION
For large databases, a timeout of 30 minutes may not be enough to wait for postgresql to start. We will get an error message if it takes longer to reach the consistency point.

Example:

```
2023-05-19 04:00:02 INFO: [STEP 1]: Starting
2023-05-19 04:00:02 INFO: Starting. Restore Type: Full PostgreSQL Restore FROM Stanza: drmdb-cluster --> TO Directory: /data/restore/drmdb-cluster
2023-05-19 04:00:02 INFO: Starting. Restore Settings: immediate
2023-05-19 04:00:02 INFO: Starting. Run settings: Log: /var/log/pgbackrest/pgbackrest_auto_drmdb-cluster.log
2023-05-19 04:00:02 INFO: Starting. Run settings: Lock run: /tmp/pgbackrest_auto_drmdb-cluster.lock
2023-05-19 04:00:02 INFO: Starting. PostgreSQL version: 13
2023-05-19 04:00:02 INFO: Starting. PostgreSQL data directory: /data/restore/drmdb-cluster
2023-05-19 04:00:02 INFO: Starting. PostgreSQL Database Validation: checksums
2023-05-19 04:00:02 INFO: Starting. Clear Data Directory after restore: yes
2023-05-19 04:00:02 WARN: Restoring to /data/restore/drmdb-cluster Waiting 30 seconds. The directory will be overwritten. If mistake, press ^C
2023-05-19 04:00:32 INFO: [STEP 2]: Stopping PostgreSQL
2023-05-19 04:00:49 INFO: attempt: 1/3600
2023-05-19 04:00:49 INFO: PostgreSQL check status
2023-05-19 04:00:49 INFO: PostgreSQL instance not running
2023-05-19 04:00:49 INFO: [STEP 3]: Restoring from backup
2023-05-19 04:00:50 INFO: See detailed log in the file /var/log/pgbackrest/drmdb-cluster-restore.log
2023-05-19 04:00:50 INFO: Restore from backup started. Type: Full PostgreSQL Restore
pgbackrest --config=/etc/pgbackrest.conf --stanza=drmdb-cluster --pg1-path=/data/restore/drmdb-cluster  --type=immediate --delta restore --process-max=4 --log-level-console=error --log-level-file=detail --recovery-option=recovery_target_action=promote --tablespace-map-all=/data/restore/drmdb-cluster_remapped_tablespaces
2023-05-19 08:31:42 INFO: Restore from backup done
2023-05-19 08:31:42 INFO: [STEP 4]: PostgreSQL Starting for recovery
2023-05-19 08:31:43 INFO: Starting PostgreSQL on port 5432
2023-05-19 09:03:05 ERROR: PostgreSQL instance 5432 start failed

```

Now we have increased the default timeout to 10 hours (-t 1800 - 36000).